### PR TITLE
Fix auth information, to make it match reality

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -3,7 +3,7 @@
     "source-url": "git://github.com/jnthn/json-path.git",
     "depends": ["JSON::Fast"],
     "authors": [ "Jonathan Worthington <jonathan@edument.se>" ],
-    "auth": "jnthn",
+    "auth": "cpan:JNTHN",
     "provides": {"JSON::Path": "lib/JSON/Path.pm6"},
     "name": "JSON::Path",
     "description": "Implementation of the JSONPath data structure query language.",


### PR DESCRIPTION
Just "jnthn" is of doutbful quality as an auth ID.  Since the module lives on CPAN (at least for now), make sure the auth is correct.

Better still would be "zef:jnthn" of course, but then the module would need to be moved to the zef ecosystem as well.